### PR TITLE
Fixes crash when calling read() method without argument

### DIFF
--- a/cp2110/__init__.py
+++ b/cp2110/__init__.py
@@ -202,6 +202,6 @@ class CP2110Device(object):
 
   def read(self, size=None):
     if size is None:
-      size = cp2110.RX_TX_MAX + 1
+      size = RX_TX_MAX + 1
 
     return self.device.read(size)[1:]


### PR DESCRIPTION
When calling the *read()* method, one faces a crash due to the `cp2110.` prefix added to the variable `RX_TX_MAX`:

```
Traceback (most recent call last):
[...]
    size = cp2110.RX_TX_MAX + 1
NameError: name 'cp2110' is not defined
```

This pull request fixes the issue by just removing the prefix and let the Python interpreter use the constant as it is used elsewhere in the same `__init__.py` file (l.185 and l.186).
